### PR TITLE
Use obj.Schema() instead of obj.schema in the migration process

### DIFF
--- a/src/plone/app/blob/migrations.py
+++ b/src/plone/app/blob/migrations.py
@@ -63,7 +63,7 @@ def makeMigrator(context, portal_type, meta_type=None):
         def migrate_data(self):
             fields = self.getFields(self.obj)
             for name in fields:
-                oldfield = self.obj.schema[name]
+                oldfield = self.obj.Schema()[name]
                 if hasattr(oldfield, 'removeScales'):
                     # clean up old image scales
                     oldfield.removeScales(self.obj)


### PR DESCRIPTION
Use obj.Schema() instead of obj.schema or some fields (like the ones provided by archetypes.schemaextender) are not taken into account...

All tests still pass, thank you for merging ;-)

Gauthier
