### PR TITLE
Enable user to save file with original name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,16 @@ Changelog
 - Make sure the id is safe before setting the filename as id
   [pbauer]
 
+- Enable user to save file with original name 
+
+  A file uploaded into Plone was saved as a normalized name,
+  when user try to download the file, they got a normalized
+  name, but the original name is prefered.
+
+  The safe way to do this is add url-encoded file name in UTF-8
+  in to the content header.
+  [yangh]
+
 
 1.5.8 (2013-04-06)
 ------------------

--- a/src/plone/app/blob/field.py
+++ b/src/plone/app/blob/field.py
@@ -14,6 +14,7 @@ from ZODB.blob import Blob
 from persistent import Persistent
 from transaction import savepoint
 from webdav.common import rfc1123_date
+from urllib import quote as url_quote
 
 from Products.CMFCore.permissions import View
 from Products.Archetypes.atapi import ObjectField, FileWidget, ImageWidget
@@ -89,11 +90,14 @@ class BlobWrapper(Implicit, Persistent):
         if filename is not None:
             if not isinstance(filename, unicode):
                 filename = unicode(filename, charset, errors="ignore")
+            quoted_filename = url_quote(filename.encode("utf8"))
             filename = IUserPreferredFileNameNormalizer(REQUEST).normalize(
                 filename)
             header_value = contentDispositionHeader(
                 disposition=disposition,
                 filename=filename)
+            # Add original filename in utf-8, ref to rfc2231
+            header_value = header_value + "; filename*=UTF-8''" + quoted_filename
             RESPONSE.setHeader("Content-disposition", header_value)
 
         request_range = handleRequestRange(self, length, REQUEST, RESPONSE)


### PR DESCRIPTION
Add file's original name in the header, ref to the RFC 2231

A file uploaded into Plone was saved as a normalized name,
when user try to download the file, they got a normalized name, 
but the original name is preffer.

The safe way to do this is add url-encoded file name in UTF-8 in to the content header. 

The reason not to do this in the ArcheType.contentDispositionHeader, is because the 'filename*' can't be used as a var name, and the filename already be normalized before pass to it.
