### PR TITLE
mimetype can't be None and always use filename if available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.5.9 (unreleased)
 ------------------
 
+- Make sure mimetype is not None and use use filename for detection if available.
+  [tschanzt]
+
 - Make sure the id is safe before setting the filename as id
   [pbauer]
 

--- a/src/plone/app/blob/field.py
+++ b/src/plone/app/blob/field.py
@@ -234,13 +234,18 @@ class BlobField(ObjectField):
         blob = BlobWrapper(self.default_content_type)
         if isinstance(value, basestring):
             value = StringIO(value)     # simple strings cannot be adapted...
+            setattr(value, 'filename', kwargs.get('filename', None))
         if value is not None:
             blobbable = IBlobbable(value)
             try:
                 blobbable.feed(blob.getBlob())
             except ReuseBlob, exception:
                 blob.setBlob(exception.args[0])     # reuse the given blob
-            blob.setContentType(kwargs.get('mimetype', blobbable.mimetype()))
+            mimetype = kwargs.get('mimetype', None)
+            if not mimetype:
+                mimetype = blobbable.mimetype()
+            if mimetype and mimetype != 'None':
+                blob.setContentType(mimetype)
             blob.setFilename(kwargs.get('filename', blobbable.filename()))
         super(BlobField, self).set(instance, blob, **kwargs)
         # a transaction savepoint is created after setting the blob's value

--- a/src/plone/app/blob/tests/test_base_fields.py
+++ b/src/plone/app/blob/tests/test_base_fields.py
@@ -7,7 +7,6 @@ from plone.app.blob.config import packageName, permissions
 from plone.app.blob.field import FileField, ImageField
 from plone.app.blob.tests.utils import getFile
 
-
 SampleSchema = BaseSchema.copy() + Schema((
 
     FileField(
@@ -83,6 +82,20 @@ class BaseFieldTests(ReplacementTestCase):
         field = item.getField('hmm')
         self.assertEqual(field.getSize(item), (0, 0))
 
+    def testSetFieldDefaultMime(self):
+        item = self.create()
+        file_ = getFile('test.pdf')
+        item.setFoo(file_, filename='file.blubb', mimetype=None)
+        self.assertEqual('application/pdf', item.getFoo().getContentType())
+
+    def testStringDataRespectsFilename(self):
+        item = self.create()
+        file_ = getFile('test.pdf')
+        item.setFoo(file_.read(), filename='file.xls', mimetype=None)
+        self.assertEqual(
+            'application/vnd.ms-excel',
+            item.getFoo().getContentType()
+            )
 
 def test_suite():
     from unittest import defaultTestLoader


### PR DESCRIPTION
I tried to eliminate the possibility of the mimetype being none, since it isn't a correct mimetype and will raise an error every time you try to access the mimetype of this file.
Also it is now possible to use the filename if the value is a string. So we can find the mimetype based on the extension and not only with the magic bytes so we can distinguish more contenttypes.
