### PR TITLE
fix inline migrator for AT types and add option to remove data in old field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.5.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix migrator for AT-based types that got broken in 1.5.8 release and add
+  an option to remove the content of the non-blob field during migration to
+  not end up having stale data in the ZODB
+  [fRiSi]
 
 
 1.5.15 (2015-05-31)
@@ -45,6 +48,7 @@ Changelog
 
 - ported tests to plone.app.testing
   [tomgross]
+
 
 1.5.10 (2014-04-16)
 -------------------


### PR DESCRIPTION
adding a test for this is a lot of work since we'd need a separate contenttype using an imagefield and register a schemaextender using a blobimagefield for it. (similar to the example provided in the [upgrade guide](https://plone.org/documentation/manual/upgrade-guide/version/upgrading-plone-3-x-to-4.0/updating-add-on-products-for-plone-4.0/use-plone.app.blob-based-blob-storage))

see https://github.com/plone/plone.app.blob/commit/f57656ee2c5e483fd02db0d2ac256d6e98d9e609 for initial discussion.