### PR TITLE
plone.app.blob does not get exported with the genericsetup contenthandler

### DIFF
--- a/src/plone/app/blob/content.py
+++ b/src/plone/app/blob/content.py
@@ -20,6 +20,7 @@ from Products.ATContentTypes.content.file import ATFile
 from Products.ATContentTypes.content.schemata import ATContentTypeSchema
 from Products.ATContentTypes.content.schemata import finalizeATCTSchema
 from Products.MimetypesRegistry.common import MimeTypeException
+from Products.GenericSetup.interfaces import IDAVAware
 
 from plone.app.imaging.interfaces import IImageScaleHandler
 from plone.app.blob.interfaces import IATBlob, IATBlobFile, IATBlobImage
@@ -73,7 +74,7 @@ def addATBlobImage(container, id, **kwargs):
 
 class ATBlob(ATCTFileContent, ImageMixin):
     """ a chunk of binary data """
-    implements(IATBlob)
+    implements(IATBlob, IDAVAware)
 
     portal_type = 'Blob'
     _at_rename_after_creation = True

--- a/src/plone/app/blob/tests/test_replacements.py
+++ b/src/plone/app/blob/tests/test_replacements.py
@@ -1,5 +1,6 @@
 from plone.app.blob.tests.base import ReplacementTestCase   # import first!
 
+from unittest import defaultTestLoader
 from zope.interface.interfaces import IInterface
 from zope.annotation import IAnnotations
 from Products.Archetypes.atapi import ImageField, AnnotationStorage
@@ -10,6 +11,8 @@ from Products.ATContentTypes.interfaces import IATFile as Z2IATFile
 from Products.ATContentTypes.interfaces import IATImage as Z2IATImage
 from Products.ATContentTypes.content.file import ATFile
 from Products.ATContentTypes.content.image import ATImage
+from Products.GenericSetup.interfaces import IFilesystemExporter, \
+    IFilesystemImporter
 from plone.app.blob.interfaces import IATBlobFile, IATBlobImage
 from plone.app.blob.migrations import migrate
 from plone.app.blob.migrations import migrateATBlobFiles, migrateATBlobImages
@@ -152,6 +155,11 @@ class FileReplacementTests(ReplacementTestCase):
         self.assertTrue(blobfile.endswith(SAVEPOINT_SUFFIX))
         self.assertTrue(blobfile.startswith(tempdir))
 
+    def testGSContentCompatible(self):
+        foo = self.folder[self.folder.invokeFactory('File', 'foo',
+            title='foo', file=getData('plone.pdf'))]
+        self.assertTrue(IFilesystemExporter(foo))
+        self.assertTrue(IFilesystemImporter(foo))
 
 class ImageReplacementTests(ReplacementTestCase):
 
@@ -335,3 +343,8 @@ class ImageReplacementTests(ReplacementTestCase):
         image = self.folder[self.folder.invokeFactory('Image', 'foo')]
         field = image.getField('image')
         self.assertEqual(field.getSize(image), (0, 0))
+
+    def testGSContentCompatible(self):
+        foo = self.folder[self.folder.invokeFactory('Image', 'foo')]
+        self.assertTrue(IFilesystemExporter(foo))
+        self.assertTrue(IFilesystemImporter(foo))


### PR DESCRIPTION
See https://dev.plone.org/ticket/10978

When exporting content, an entry in .objects is created but no representation of the file. Whats missing the ATBlob should declare that it implements Products.GenericSetup.interfaces.IDAVAware. But then the PrimaryFieldMarshaller complains that the return value of the image field is not an instance of the IBAseUnit.

@witsch 
