### PR TITLE
Do not use imports from Products.ATContentTypes.interface deprecated …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do not use imports from ``Products.ATContentTypes.interface`` deprecated since 2009.
+  [jensens]
 
 
 1.7 (2017-04-01)

--- a/src/plone/app/blob/adapters/atimage.py
+++ b/src/plone/app/blob/adapters/atimage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.app.blob.adapters.atfile import BlobbableATFile
-from Products.ATContentTypes.interface import IATImage
+from Products.ATContentTypes.interfaces import IATImage
 from zope.component import adapts
 
 

--- a/src/plone/app/blob/markings.py
+++ b/src/plone/app/blob/markings.py
@@ -5,8 +5,8 @@
 from plone.app.blob.interfaces import IATBlobBlob
 from plone.app.blob.interfaces import IATBlobFile
 from plone.app.blob.interfaces import IATBlobImage
-from Products.ATContentTypes.interface import file as atfile
-from Products.ATContentTypes.interface import image as atimage
+from Products.ATContentTypes.interfaces import file as atfile
+from Products.ATContentTypes.interfaces import image as atimage
 from Products.ATContentTypes.interfaces import IATFile as Z2IATFile
 from Products.ATContentTypes.interfaces import IATImage as Z2IATImage
 from zope.interface import alsoProvides

--- a/src/plone/app/blob/tests/test_maintenance.py
+++ b/src/plone/app/blob/tests/test_maintenance.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from plone.app.blob.markings import unmarkAs
 from plone.app.blob.tests.base import ReplacementTestCase  # import first!
-from Products.ATContentTypes.interface import file as atfile
-from Products.ATContentTypes.interface import image as atimage
+from Products.ATContentTypes.interfaces import file as atfile
+from Products.ATContentTypes.interfaces import image as atimage
 
 try:
     from Products.CMFCore.indexing import processQueue

--- a/src/plone/app/blob/tests/test_replacements.py
+++ b/src/plone/app/blob/tests/test_replacements.py
@@ -15,8 +15,8 @@ from Products.Archetypes.atapi import ImageField
 from Products.Archetypes.Field import Image
 from Products.ATContentTypes.content.file import ATFile
 from Products.ATContentTypes.content.image import ATImage
-from Products.ATContentTypes.interface import file as atfile
-from Products.ATContentTypes.interface import image as atimage
+from Products.ATContentTypes.interfaces import file as atfile
+from Products.ATContentTypes.interfaces import image as atimage
 from Products.ATContentTypes.interfaces import IATFile as Z2IATFile
 from Products.ATContentTypes.interfaces import IATImage as Z2IATImage
 from Products.GenericSetup.interfaces import IFilesystemExporter


### PR DESCRIPTION
…since 2009.

This is not important, but I stumbled across it.