### PR TITLE
Handle ValueError exceptions when doing a range request. (Fixes issue #39)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Handle ``ValueError`` exceptions when doing a range request.
+  This fixes `issue #39 <https://github.com/plone/plone.app.blob/issues/39>`_.
+  [batlock666]
 
 
 1.7.1 (2017-05-16)

--- a/src/plone/app/blob/download.py
+++ b/src/plone/app/blob/download.py
@@ -73,12 +73,15 @@ def handleRequestRange(instance, length, REQUEST, RESPONSE):
                         ranges = None
             RESPONSE.setHeader('Accept-Ranges', 'bytes')
         if ranges and len(ranges) == 1:
-            [(start, end)] = expandRanges(ranges, length)
-            size = end - start
-            RESPONSE.setHeader('Content-Length', size)
-            RESPONSE.setHeader(
-                'Content-Range',
-                'bytes {0}-{1}/{2}'.format(start, end - 1, length))
-            RESPONSE.setStatus(206)  # Partial content
-            return dict(start=start, end=end)
+            try:
+                [(start, end)] = expandRanges(ranges, length)
+                size = end - start
+                RESPONSE.setHeader('Content-Length', size)
+                RESPONSE.setHeader(
+                    'Content-Range',
+                    'bytes {0}-{1}/{2}'.format(start, end - 1, length))
+                RESPONSE.setStatus(206)  # Partial content
+                return dict(start=start, end=end)
+            except ValueError:
+                return {}
     return {}

--- a/src/plone/app/blob/tests/test_integration.py
+++ b/src/plone/app/blob/tests/test_integration.py
@@ -153,6 +153,21 @@ class IntegrationTests(BlobTestCase):
         iterator = blob.download(request)
         self.assertEqual(data[-20:], ''.join(iterator))
 
+    def testOutsideRange(self):
+        # ranges outside the file size also have to work
+        blob = self.folder['blob']
+        blob.setTitle('foo')
+        blob.setFile(getData('plone.pdf'))
+        data = blob.getFile().getBlob().open('r').read()
+        l = len(data)
+        request = self.folder.REQUEST
+        request.environ['HTTP_RANGE'] = 'bytes={}-{}'.format(l * 2, l * 3)
+        iterator = blob.download(request)
+        self.assertEqual(data, ''.join(iterator))
+        request.environ['HTTP_RANGE'] = 'bytes={}-'.format(l * 2)
+        iterator = blob.download(request)
+        self.assertEqual(data, ''.join(iterator))
+
     def testIcon(self):
         blob = self.folder.blob
         blob.update(file=getImage())


### PR DESCRIPTION
This should fix issue #39.

Sorry for the previous pull request. I used the wrong account for that one.