### PR TITLE
Fix regression introduced by #26

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@ Bug fixes:
 - Remove no longer existing icons from type definitions.
   [davisagli]
 
+- Fix bug where Image blob fields couldn't be used with
+  archetypes.schemaextender unless the parent class subclasses
+  ATCTImageTransform
+  [MatthewWilkes]
+
 
 1.7.2 (2017-06-03)
 ------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -7,14 +7,12 @@ extensions = mr.developer
 sources = sources
 sources-dir = src-dev
 auto-checkout = 
-    plone.app.testing
-    plone.app.imaging
-    Products.GenericSetup
 
 [remotes]
 plone = git://github.com/plone
 plone_push = git@github.com:plone
-zope = svn://svn.zope.org/repos/main/
+zope = git://github.com/zopefoundation
+zope_push = git@github.com:zopefoundation
 
 [versions]
 plone.app.testing =
@@ -23,4 +21,4 @@ plone.app.blob =
 [sources]
 plone.app.testing         = git ${remotes:plone}/plone.app.testing.git pushurl=${remotes:plone_push}/plone.app.testing.git branch=master
 plone.app.imaging         = git ${remotes:plone}/plone.app.imaging.git pushurl=${remotes:plone_push}/plone.app.imaging.git branch=master
-Products.GenericSetup     = svn svn://svn.zope.org/repos/main/Products.GenericSetup/trunk
+Products.GenericSetup     = git ${remotes:zope}/Products.GenericSetup.git pushurl=${remotes:zope_push}/Products.GenericSetup.git branch=master

--- a/src/plone/app/blob/subtypes/image.py
+++ b/src/plone/app/blob/subtypes/image.py
@@ -21,7 +21,11 @@ class ExtensionBlobField(ExtensionField, BlobField, ImageFieldMixin):
     def set(self, instance, value, refresh_exif=True, **kwargs):
         super(ExtensionBlobField, self).set(instance, value, **kwargs)
         self.fixAutoId(instance)
-        instance.getEXIF(value, refresh=refresh_exif)
+        if hasattr(instance, 'getEXIF'):
+            # If the instance subclasses ATCTImageTransform we process the
+            # metadata.
+            # TODO: The EXIF functionality should not be dependent on ATCT
+            instance.getEXIF(value, refresh=refresh_exif)
         if hasattr(aq_base(instance), blobScalesAttr):
             delattr(aq_base(instance), blobScalesAttr)
 

--- a/src/plone/app/blob/tests/base.py
+++ b/src/plone/app/blob/tests/base.py
@@ -2,6 +2,7 @@
 from plone.app.blob.tests.layer import BlobLayer
 from plone.app.blob.tests.layer import BlobLinguaLayer
 from plone.app.blob.tests.layer import BlobReplacementLayer
+from plone.app.blob.tests.layer import BlobSchemaExtenderLayer
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.testing.bbb import PloneTestCase
@@ -35,6 +36,12 @@ class ReplacementTestCase(BlobTestCase):
     layer = BlobReplacementLayer
 
 ReplacementFunctionalTestCase = ReplacementTestCase
+
+
+class BlobSchemaExtenderTestCase(PloneTestCase):
+    """ base class for schemaextender tests """
+
+    layer = BlobSchemaExtenderLayer
 
 
 class BlobLinguaTestCase(PloneTestCase):

--- a/src/plone/app/blob/tests/extender.py
+++ b/src/plone/app/blob/tests/extender.py
@@ -1,0 +1,36 @@
+from zope.component import adapts
+from zope.interface import implements
+from archetypes.schemaextender.interfaces import ISchemaExtender
+from Products.ATContentTypes.interfaces import IATDocument, IATImage
+
+from plone.app.blob.subtypes.image import ExtensionBlobField
+
+
+class PageImageAdder(object):
+    adapts(IATDocument)
+    implements(ISchemaExtender)
+
+    fields = [
+        ExtensionBlobField("image"),
+    ]
+
+    def __init__(self, context):
+        self.context = context
+
+    def getFields(self):
+        return self.fields
+
+
+class ImageImageAdder(object):
+    adapts(IATImage)
+    implements(ISchemaExtender)
+
+    fields = [
+        ExtensionBlobField("new_image"),
+    ]
+
+    def __init__(self, context):
+        self.context = context
+
+    def getFields(self):
+        return self.fields

--- a/src/plone/app/blob/tests/extender.zcml
+++ b/src/plone/app/blob/tests/extender.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:monkey="http://namespaces.plone.org/monkey"
+    i18n_domain="plone.app.blob">
+
+    <include package="archetypes.schemaextender" />
+    <adapter factory=".extender.PageImageAdder" />
+    <adapter factory=".extender.ImageImageAdder" />
+
+</configure>

--- a/src/plone/app/blob/tests/layer.py
+++ b/src/plone/app/blob/tests/layer.py
@@ -81,6 +81,32 @@ BlobReplacementLayer = testing.FunctionalTesting(
 BlobFileReplacementLayer = BlobReplacementLayer
 
 
+class BlobSchemaExtenderFixture(PloneTestCaseFixture):
+    """ layer for integration tests with SchemaExtender """
+
+    defaultBases = (PTC_FIXTURE, )
+
+    def setUpZope(self, app, configurationContext):
+        import archetypes.schemaextender
+        self.loadZCML(package=archetypes.schemaextender)
+        import plone.app.blob
+        self.loadZCML(package=plone.app.blob)
+        self.loadZCML(name='extender.zcml', package=plone.app.blob.tests)
+        z2.installProduct(app, 'plone.app.blob')
+        z2.installProduct(app, 'archetypes.schemaextender')
+
+    def tearDownZope(self, app):
+        z2.uninstallProduct(app, 'plone.app.blob')
+        z2.uninstallProduct(app, 'archetypes.schemaextender')
+
+
+BLOB_SCHEMA_EXTENDER_FIXTURE = BlobSchemaExtenderFixture()
+BlobSchemaExtenderLayer = testing.FunctionalTesting(
+    bases=(BLOB_SCHEMA_EXTENDER_FIXTURE, ),
+    name='Blob SchemaExtender:Functional',
+)
+
+
 class BlobLinguaFixture(PloneTestCaseFixture):
     """ layer for integration tests with LinguaPlone """
 

--- a/src/plone/app/blob/tests/patches.py
+++ b/src/plone/app/blob/tests/patches.py
@@ -14,5 +14,6 @@ def setBody(self, body, *args, **kw):
 
 
 def applyPatch(scope, original, replacement):
-    setattr(scope, '_original_' + original, getattr(scope, original))
+    if not hasattr(scope, '_original_'+original):
+        setattr(scope, '_original_' + original, getattr(scope, original))
     setattr(scope, original, replacement)

--- a/src/plone/app/blob/tests/test_extensionblobfield.py
+++ b/src/plone/app/blob/tests/test_extensionblobfield.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from unittest import defaultTestLoader
+from unittest import TestSuite
+
+from plone.app.blob.tests.base import BlobSchemaExtenderTestCase
+from plone.app.blob.tests.utils import hasSchemaExtender
+
+
+class ExtenderTests(BlobSchemaExtenderTestCase):
+
+    def testImageOnDocument(self):
+        """Test that adding an image blob field to a document doesn't
+        error for lack of EXIF helper functions"""
+        document_id = self.folder.invokeFactory('Document', id='doc')
+        document = self.folder[document_id]
+        document.Schema().get('image').set(document, 'f')
+
+    def testImageOnImage(self):
+        """Test that an extension image field works on a class that has image
+        helper methods"""
+        img_id = self.folder.invokeFactory('Image', id='img')
+        img = self.folder[img_id]
+        img.Schema().get('new_image').set(img, 'f')
+
+
+def test_suite():
+    if hasSchemaExtender():
+        return defaultTestLoader.loadTestsFromName(__name__)
+    else:
+        return TestSuite()

--- a/src/plone/app/blob/tests/utils.py
+++ b/src/plone/app/blob/tests/utils.py
@@ -60,3 +60,17 @@ def hasLinguaPlone():
         print msg
         print '*' * len(msg)
         return False
+
+
+def hasSchemaExtender():
+    """ test if SchemaExtender is available """
+    try:
+        import archetypes.schemaextender
+        archetypes.schemaextender     # make pyflakes happy...
+        return True
+    except ImportError:
+        msg = 'WARNING: archetypes.schemaextender not found. Skipping tests.'
+        print '*' * len(msg)
+        print msg
+        print '*' * len(msg)
+        return False


### PR DESCRIPTION
The fix in #26 to update EXIF data requires the instance be a subclass of `ATCTImageTransform`, meaning image blob fields can't be added to, for example, ATDocument.