### PR TITLE
Fixed deprecation warning for MimeTypeException [5.1]

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warning for MimeTypeException from MimetypesRegistry.common.
+[maurits]

--- a/src/plone/app/blob/content.py
+++ b/src/plone/app/blob/content.py
@@ -20,7 +20,7 @@ from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import getToolByName
 from Products.GenericSetup.interfaces import IDAVAware
-from Products.MimetypesRegistry.common import MimeTypeException
+from Products.MimetypesRegistry.interfaces import MimeTypeException
 from ZODB.POSException import ConflictError
 from zope.event import notify
 from zope.interface import implementer


### PR DESCRIPTION
```
plone/app/blob/content.py:23:
  DeprecationWarning: MimeTypeException is deprecated.
  Import from Products.MimetypesRegistry.interfaces instead

  from Products.MimetypesRegistry.common import MimeTypeException
```

This is one of only two deprecation warnings that I now see when starting Plone 5.1.